### PR TITLE
Empty string translation issue

### DIFF
--- a/Block/Adminhtml/Job/Grid/Renderer/Action.php
+++ b/Block/Adminhtml/Job/Grid/Renderer/Action.php
@@ -57,7 +57,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Action
         } else {
             $this->getColumn()->setActions([[
                 'url' => '',
-                'caption' => __(''),
+                'caption' => '',
             ]]);
         }
 


### PR DESCRIPTION
After adding Translation file error:
Missed phrase in ./vendor/reflektion/reflektion_magento_2/Block/Adminhtml/Job/Grid/Renderer/Action.php:60